### PR TITLE
Fix reloading of Windy map modal

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -33,7 +33,8 @@ import {
   setupModalMapToggle,
   setupModalCleanup,
   setupLongPressShare,
-  setupOverviewModal
+  setupOverviewModal,
+  setupWeatherModal
 } from './modal.js';
 
 import {
@@ -145,6 +146,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   setupModalMapToggle();
   setupModalCleanup();
   setupOverviewModal();
+  setupWeatherModal();
   setupCopyUrlButton();
   setupCustomRouteBuilder();
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -392,4 +392,24 @@ const bounds = L.latLngBounds(coords);
   });
 }
 
+// ---- WEATHER MODAL ----
+export function setupWeatherModal() {
+  const modal = document.getElementById('weatherModal');
+  if (!modal) return;
+
+  modal.addEventListener('show.bs.modal', () => {
+    const iframe = modal.querySelector('iframe');
+    if (iframe && window.currentWindyUrl) {
+      iframe.src = window.currentWindyUrl;
+    }
+  });
+
+  modal.addEventListener('hidden.bs.modal', () => {
+    const iframe = modal.querySelector('iframe');
+    if (iframe) {
+      iframe.src = '';
+    }
+  });
+}
+
 

--- a/js/otherFilters.js
+++ b/js/otherFilters.js
@@ -206,9 +206,13 @@ export async function applyOtherFilter(name) {
 
   // 4) update the Windy.com iframe in your #weatherModal
   if (cfg.windyParams) {
+    const url = buildWindyUrl(cfg.windyParams);
+    window.currentWindyUrl = url;
     const iframe = document.querySelector('#weatherModal iframe');
     if (iframe) {
-      iframe.src = buildWindyUrl(cfg.windyParams);
+      iframe.src = url;
     }
+  } else {
+    window.currentWindyUrl = '';
   }
 }


### PR DESCRIPTION
## Summary
- keep track of current Windy map URL for the weather modal
- reload iframe each time the weather modal is shown and clear it when hidden
- hook up weather modal setup in main initialization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68658496635483219c15c783d1022b82